### PR TITLE
add countdown timer and refresh for shown codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## unreleased
+- Improvements
+  - Add countdown bar indicating remaining time for shown codes
+  - Add auto refresh for shown codes
+
+
 ## 0.0.4 - 2026-06-01
 - New Features
   - Add grid layout and layout toggle

--- a/client/src/components/OtpListItem.tsx
+++ b/client/src/components/OtpListItem.tsx
@@ -2,7 +2,7 @@ import { IconEye, IconEyeOff } from '@tabler/icons-solidjs'
 import { Result } from 'better-result'
 import type { OtpDisplayInfo } from 'shared/src/types'
 import type { Component } from 'solid-js'
-import { createEffect, createMemo, createSignal, onCleanup, Show } from 'solid-js'
+import { createEffect, createSignal, onCleanup, Show } from 'solid-js'
 import { fetch_otp_code } from '../otp_list_item'
 
 type Props = {
@@ -15,20 +15,14 @@ const OtpListItem: Component<Props> = (props) => {
 	const [isCodeVisible, setIsCodeVisible] = createSignal(false)
 	const [isLoadingCode, setIsLoadingCode] = createSignal(false)
 	const [showCopyToast, setShowCopyToast] = createSignal(false)
-	const [nowEpochMs, setNowEpochMs] = createSignal(Date.now())
-	const [lastPeriodCounter, setLastPeriodCounter] = createSignal<number | null>(null)
+	const [timerAlignmentMs, setTimerAlignmentMs] = createSignal(0)
 	let copyToastTimer: ReturnType<typeof setTimeout> | undefined
-	let tickTimer: ReturnType<typeof setInterval> | undefined
+	let refreshBoundaryTimer: ReturnType<typeof setTimeout> | undefined
+	let refreshIntervalTimer: ReturnType<typeof setInterval> | undefined
 	let isAutoRefreshingCode = false
 
 	const periodSeconds = Math.max(1, props.otp.period)
-
-	const periodCounter = createMemo(() => Math.floor(nowEpochMs() / 1000 / periodSeconds))
-
-	const remainingRatio = createMemo(() => {
-		const elapsedInPeriod = (nowEpochMs() / 1000) % periodSeconds
-		return (periodSeconds - elapsedInPeriod) / periodSeconds
-	})
+	const periodMs = periodSeconds * 1000
 
 	const issuerSecond = props.otp.issuer_second.trim()
 	const issuerText =
@@ -38,7 +32,7 @@ const OtpListItem: Component<Props> = (props) => {
 		if (isCodeVisible()) {
 			setCode(null)
 			setIsCodeVisible(false)
-			setLastPeriodCounter(null)
+			setTimerAlignmentMs(0)
 			return
 		}
 
@@ -54,8 +48,8 @@ const OtpListItem: Component<Props> = (props) => {
 		}
 
 		setCode(code_res.value)
+		setTimerAlignmentMs(Date.now() % periodMs)
 		setIsCodeVisible(true)
-		setLastPeriodCounter(periodCounter())
 	}
 
 	async function refreshVisibleCode() {
@@ -80,46 +74,38 @@ const OtpListItem: Component<Props> = (props) => {
 	}
 
 	createEffect(() => {
-		if (tickTimer !== undefined) {
-			clearInterval(tickTimer)
-			tickTimer = undefined
+		if (refreshBoundaryTimer !== undefined) {
+			clearTimeout(refreshBoundaryTimer)
+			refreshBoundaryTimer = undefined
+		}
+
+		if (refreshIntervalTimer !== undefined) {
+			clearInterval(refreshIntervalTimer)
+			refreshIntervalTimer = undefined
 		}
 
 		if (!isCodeVisible()) {
 			return
 		}
 
-		setNowEpochMs(Date.now())
-		tickTimer = setInterval(() => {
-			setNowEpochMs(Date.now())
-		}, 100)
-	})
-
-	createEffect(() => {
-		if (!isCodeVisible()) {
-			return
-		}
-
-		const currentCounter = periodCounter()
-		const previousCounter = lastPeriodCounter()
-
-		if (previousCounter === null) {
-			setLastPeriodCounter(currentCounter)
-			return
-		}
-
-		if (currentCounter !== previousCounter) {
-			setLastPeriodCounter(currentCounter)
+		const msToNextPeriod = periodMs - (Date.now() % periodMs)
+		refreshBoundaryTimer = setTimeout(() => {
 			void refreshVisibleCode()
-		}
+			refreshIntervalTimer = setInterval(() => {
+				void refreshVisibleCode()
+			}, periodMs)
+		}, msToNextPeriod)
 	})
 
 	onCleanup(() => {
 		if (copyToastTimer !== undefined) {
 			clearTimeout(copyToastTimer)
 		}
-		if (tickTimer !== undefined) {
-			clearInterval(tickTimer)
+		if (refreshBoundaryTimer !== undefined) {
+			clearTimeout(refreshBoundaryTimer)
+		}
+		if (refreshIntervalTimer !== undefined) {
+			clearInterval(refreshIntervalTimer)
 		}
 	})
 
@@ -199,7 +185,7 @@ const OtpListItem: Component<Props> = (props) => {
 			<div class="otp-list__timer-track" aria-hidden="true">
 				<div
 					class={`otp-list__timer-fill ${isCodeVisible() ? 'otp-list__timer-fill--active' : ''}`}
-					style={{ transform: `scaleX(${remainingRatio()})` }}
+					style={`--otp-period-seconds:${periodSeconds}s;--otp-offset-seconds:-${timerAlignmentMs() / 1000}s;`}
 				/>
 			</div>
 		</li>

--- a/client/src/components/OtpListItem.tsx
+++ b/client/src/components/OtpListItem.tsx
@@ -2,7 +2,7 @@ import { IconEye, IconEyeOff } from '@tabler/icons-solidjs'
 import { Result } from 'better-result'
 import type { OtpDisplayInfo } from 'shared/src/types'
 import type { Component } from 'solid-js'
-import { createSignal, onCleanup, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, onCleanup, Show } from 'solid-js'
 import { fetch_otp_code } from '../otp_list_item'
 
 type Props = {
@@ -15,7 +15,20 @@ const OtpListItem: Component<Props> = (props) => {
 	const [isCodeVisible, setIsCodeVisible] = createSignal(false)
 	const [isLoadingCode, setIsLoadingCode] = createSignal(false)
 	const [showCopyToast, setShowCopyToast] = createSignal(false)
+	const [nowEpochMs, setNowEpochMs] = createSignal(Date.now())
+	const [lastPeriodCounter, setLastPeriodCounter] = createSignal<number | null>(null)
 	let copyToastTimer: ReturnType<typeof setTimeout> | undefined
+	let tickTimer: ReturnType<typeof setInterval> | undefined
+	let isAutoRefreshingCode = false
+
+	const periodSeconds = Math.max(1, props.otp.period)
+
+	const periodCounter = createMemo(() => Math.floor(nowEpochMs() / 1000 / periodSeconds))
+
+	const remainingRatio = createMemo(() => {
+		const elapsedInPeriod = (nowEpochMs() / 1000) % periodSeconds
+		return (periodSeconds - elapsedInPeriod) / periodSeconds
+	})
 
 	const issuerSecond = props.otp.issuer_second.trim()
 	const issuerText =
@@ -25,6 +38,7 @@ const OtpListItem: Component<Props> = (props) => {
 		if (isCodeVisible()) {
 			setCode(null)
 			setIsCodeVisible(false)
+			setLastPeriodCounter(null)
 			return
 		}
 
@@ -41,11 +55,71 @@ const OtpListItem: Component<Props> = (props) => {
 
 		setCode(code_res.value)
 		setIsCodeVisible(true)
+		setLastPeriodCounter(periodCounter())
 	}
+
+	async function refreshVisibleCode() {
+		if (!isCodeVisible() || isAutoRefreshingCode) {
+			return
+		}
+
+		isAutoRefreshingCode = true
+		const code_res = await fetch_otp_code(props.otp.id)
+		isAutoRefreshingCode = false
+
+		if (!isCodeVisible()) {
+			return
+		}
+
+		if (Result.isError(code_res)) {
+			props.setError(code_res.error.message)
+			return
+		}
+
+		setCode(code_res.value)
+	}
+
+	createEffect(() => {
+		if (tickTimer !== undefined) {
+			clearInterval(tickTimer)
+			tickTimer = undefined
+		}
+
+		if (!isCodeVisible()) {
+			return
+		}
+
+		setNowEpochMs(Date.now())
+		tickTimer = setInterval(() => {
+			setNowEpochMs(Date.now())
+		}, 100)
+	})
+
+	createEffect(() => {
+		if (!isCodeVisible()) {
+			return
+		}
+
+		const currentCounter = periodCounter()
+		const previousCounter = lastPeriodCounter()
+
+		if (previousCounter === null) {
+			setLastPeriodCounter(currentCounter)
+			return
+		}
+
+		if (currentCounter !== previousCounter) {
+			setLastPeriodCounter(currentCounter)
+			void refreshVisibleCode()
+		}
+	})
 
 	onCleanup(() => {
 		if (copyToastTimer !== undefined) {
 			clearTimeout(copyToastTimer)
+		}
+		if (tickTimer !== undefined) {
+			clearInterval(tickTimer)
 		}
 	})
 
@@ -122,6 +196,12 @@ const OtpListItem: Component<Props> = (props) => {
 					Copied!
 				</div>
 			</Show>
+			<div class="otp-list__timer-track" aria-hidden="true">
+				<div
+					class={`otp-list__timer-fill ${isCodeVisible() ? 'otp-list__timer-fill--active' : ''}`}
+					style={{ transform: `scaleX(${remainingRatio()})` }}
+				/>
+			</div>
 		</li>
 	)
 }

--- a/client/src/css/otp-list.css
+++ b/client/src/css/otp-list.css
@@ -58,11 +58,19 @@
 	height: 100%;
 	background: var(--palette-green);
 	transform-origin: left center;
+	transform: scaleX(1);
 	opacity: 0;
+	animation-name: otp-timer-countdown;
+	animation-duration: var(--otp-period-seconds, 30s);
+	animation-timing-function: linear;
+	animation-iteration-count: infinite;
+	animation-delay: var(--otp-offset-seconds, 0s);
+	animation-play-state: paused;
 }
 
 .otp-list__timer-fill--active {
 	opacity: 1;
+	animation-play-state: running;
 }
 
 .otp-list__copy {
@@ -191,5 +199,14 @@
 	to {
 		opacity: 1;
 		transform: translate(-50%, -100%);
+	}
+}
+
+@keyframes otp-timer-countdown {
+	from {
+		transform: scaleX(1);
+	}
+	to {
+		transform: scaleX(0);
 	}
 }

--- a/client/src/css/otp-list.css
+++ b/client/src/css/otp-list.css
@@ -42,6 +42,29 @@
 	}
 }
 
+.otp-list__timer-track {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 4px;
+	background: color-mix(in srgb, var(--color-border) 60%, transparent);
+	pointer-events: none;
+	z-index: 2;
+}
+
+.otp-list__timer-fill {
+	width: 100%;
+	height: 100%;
+	background: var(--palette-green);
+	transform-origin: left center;
+	opacity: 0;
+}
+
+.otp-list__timer-fill--active {
+	opacity: 1;
+}
+
 .otp-list__copy {
 	position: absolute;
 	inset: 0;

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -51,6 +51,7 @@ export function listEntries(): OtpDisplayInfo[] {
 			label: entries.label,
 			issuer: entries.issuer,
 			issuer_second: entries.issuer_second,
+			period: entries.period,
 		})
 		.from(entries)
 		.all()

--- a/server/src/routes/otp_routes.test.ts
+++ b/server/src/routes/otp_routes.test.ts
@@ -70,6 +70,7 @@ describe('OTP routes', () => {
 				label: 'Personal account',
 				issuer: 'example.com',
 				issuer_second: '',
+				period: 30,
 			},
 		])
 	})

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -16,4 +16,5 @@ export interface OtpDisplayInfo {
 	label: string
 	issuer: string
 	issuer_second: string
+	period: number
 }


### PR DESCRIPTION
close #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible countdown timer bar showing remaining time for each OTP code.
  * OTP codes now auto-refresh while they are visible on screen.
  * Animated progress fill aligns with each code's validity period and pauses when the code is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->