### PR TITLE
ci: add unit coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
       - run: bun run check
       - run: bun run build
       - run: bun run test
+      - run: bun run test:coverage
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: unit-coverage-lcov
+          path: coverage/lcov.info
+          retention-days: 7
       - run: bun run lint:ci
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 
 # caches
 .turbo/
+coverage/
 *.tsbuildinfo
 playwright-report/
 test-results/

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dev": "turbo run dev",
     "db:generate": "bun run --cwd server db:generate",
     "test": "turbo run test",
+    "test:coverage": "bun test server/src client/src --coverage --coverage-reporter=lcov",
     "test:smoke": "bun test tests/smoke --timeout 20000",
     "test:e2e": "playwright test"
   },


### PR DESCRIPTION
## Summary

Adds a focused coverage-report command for the existing Bun unit tests and publishes the generated LCOV report from CI.

Changes:

- Adds `bun run test:coverage`, scoped to existing unit tests under `server/src` and `client/src`
- Uploads `coverage/lcov.info` as a `unit-coverage-lcov` CI artifact
- Ignores generated `coverage/` output locally

The coverage command intentionally excludes Playwright e2e and Docker smoke tests because those already have separate CI jobs and are not compatible with direct `bun test` discovery.

## Validation

Using Bun 1.3.14 via `npx bun@1.3.14`:

- `bun install --frozen-lockfile`
- `bun run test:coverage`
- `test -s coverage/lcov.info`
- `bun run test`
- `bun run check`
- `bun run build`
- `bun run lint:ci`
- `git diff --check HEAD~1 HEAD`

Note: `bun run build` completed successfully while Vite printed the existing local Node 22.11.0 warning.

Submitted by Bean Labs as a public free-service contribution; acceptance is still pending maintainer review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured CI workflow to run test coverage and upload coverage reports as artifacts with 7-day retention.
  * Added `test:coverage` script for running tests with coverage analysis.
  * Updated `.gitignore` to exclude coverage output from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->