### PR TITLE
auth matrix test: fail on untested route

### DIFF
--- a/server/src/routes/auth-matrix.test.ts
+++ b/server/src/routes/auth-matrix.test.ts
@@ -18,7 +18,9 @@ import { createSessionId } from '../sessions'
 // Constants and types
 //
 
-const ACCEPTED_CODES = [200, 400, 404]
+const ACCEPTED_CODES = [200, 302, 400, 404]
+
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const
 
 interface Endpoint {
 	method: HttpMethod
@@ -56,7 +58,7 @@ const endpoints: Endpoint[] = [
 // 1. Test matrix completeness
 //
 
-type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE'
+type HttpMethod = (typeof HTTP_METHODS)[number]
 
 interface AppRoute {
 	method: string
@@ -68,7 +70,7 @@ function endpointKey(endpoint: Pick<Endpoint, 'method' | 'path'>): string {
 }
 
 function isHttpMethod(method: string): method is HttpMethod {
-	return method === 'GET' || method === 'POST' || method === 'PUT' || method === 'DELETE'
+	return (HTTP_METHODS as readonly string[]).includes(method)
 }
 
 function getAppEndpoints(): Endpoint[] {

--- a/server/src/routes/auth-matrix.test.ts
+++ b/server/src/routes/auth-matrix.test.ts
@@ -13,6 +13,7 @@ enum Role {
 
 // Access profiles
 const RESTRICTED = [Role.authenticated]
+const ALL_ROLES = [Role.unauthenticated, Role.authenticated]
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE'
 
@@ -22,15 +23,63 @@ interface Endpoint {
 	acceptedRoles: Role[]
 }
 
+interface AppRoute {
+	method: string
+	path: string
+}
+
+function endpointKey(endpoint: Pick<Endpoint, 'method' | 'path'>): string {
+	return `${endpoint.method} ${endpoint.path}`
+}
+
+function isHttpMethod(method: string): method is HttpMethod {
+	return method === 'GET' || method === 'POST' || method === 'PUT' || method === 'DELETE'
+}
+
+function getAppEndpoints(): Endpoint[] {
+	const ignoredRoutes = new Set<string>(['ALL /*'])
+	const unique = new Map<string, Endpoint>()
+
+	for (const route of app.routes as AppRoute[]) {
+		if (!isHttpMethod(route.method)) {
+			continue
+		}
+
+		const key = `${route.method} ${route.path}`
+		if (ignoredRoutes.has(key)) {
+			continue
+		}
+
+		unique.set(key, { method: route.method, path: route.path, acceptedRoles: [] })
+	}
+
+	return [...unique.values()]
+}
+
 // Endpoint authentication matrix
-// login and logout are not tested
 const endpoints: Endpoint[] = [
+	{ method: 'GET', path: '/auth/providers', acceptedRoles: ALL_ROLES },
+	{ method: 'GET', path: '/auth/login/microsoft', acceptedRoles: ALL_ROLES },
+	{ method: 'GET', path: '/auth/callback/microsoft', acceptedRoles: ALL_ROLES },
+	{ method: 'POST', path: '/auth/login', acceptedRoles: ALL_ROLES },
+	{ method: 'POST', path: '/auth/logout', acceptedRoles: RESTRICTED },
 	{ method: 'GET', path: '/auth/me', acceptedRoles: RESTRICTED },
 	{ method: 'GET', path: '/otp', acceptedRoles: RESTRICTED },
 	{ method: 'POST', path: '/otp', acceptedRoles: RESTRICTED },
-	{ method: 'GET', path: '/otp/test-id', acceptedRoles: RESTRICTED },
-	{ method: 'POST', path: '/otp/test-id', acceptedRoles: RESTRICTED },
+	{ method: 'GET', path: '/otp/:id', acceptedRoles: RESTRICTED },
+	{ method: 'POST', path: '/otp/:id', acceptedRoles: RESTRICTED },
 ]
+
+test('Matrix covers all registered endpoints', () => {
+	const matrixKeys = new Set(endpoints.map(endpointKey))
+	const appEndpointKeys = new Set(getAppEndpoints().map(endpointKey))
+
+	const missingInMatrix = [...appEndpointKeys].filter((key) => !matrixKeys.has(key)).sort()
+	const missingInApp = [...matrixKeys].filter((key) => !appEndpointKeys.has(key)).sort()
+
+	expect(missingInMatrix).toEqual([])
+	expect(missingInApp).toEqual([])
+})
 
 async function getAuthCookie(role: Role): Promise<string | undefined> {
 	if (role === Role.unauthenticated) {
@@ -47,10 +96,11 @@ async function getAuthCookie(role: Role): Promise<string | undefined> {
 	return `auth_token=${token}`
 }
 
-function testEndpointAccess(endpoint: Endpoint, role: Role, cookie?: string) {
+function testEndpointAccess(endpoint: Endpoint, role: Role) {
 	const isAccepted = endpoint.acceptedRoles.includes(role)
 
 	test(`${endpoint.method} ${endpoint.path} -> ${isAccepted ? 'Allowed' : '401'}`, async () => {
+		const cookie = await getAuthCookie(role)
 		const headers: Record<string, string> = {}
 		if (cookie) {
 			headers.Cookie = cookie
@@ -69,18 +119,11 @@ function testEndpointAccess(endpoint: Endpoint, role: Role, cookie?: string) {
 	})
 }
 
-const roleCookies = new Map<Role, string | undefined>()
-for (const role of [Role.unauthenticated, Role.authenticated]) {
-	roleCookies.set(role, await getAuthCookie(role))
-}
-
 describe('Auth Matrix', () => {
-	for (const role of [Role.unauthenticated, Role.authenticated]) {
-		const cookie = roleCookies.get(role)
-
+	for (const role of ALL_ROLES) {
 		describe(`Role: ${Role[role]}`, () => {
 			for (const endpoint of endpoints) {
-				testEndpointAccess(endpoint, role, cookie)
+				testEndpointAccess(endpoint, role)
 			}
 		})
 	}

--- a/server/src/routes/auth-matrix.test.ts
+++ b/server/src/routes/auth-matrix.test.ts
@@ -1,27 +1,62 @@
+// SPDX-FileCopyrightText: 2026-present Lukas Neubert
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * Test file to ensure the correct authentication is required for each endpoint.
+ * Contains two main tests:
+ * - Matrix completeness: Ensures all registered endpoints are covered by the matrix
+ * - Access control: Tests each endpoint with all defined roles / access profiles
+ */
+
 import { describe, expect, test } from 'bun:test'
 import { sign } from 'hono/jwt'
 import { app } from '../index'
 
 import { createSessionId } from '../sessions'
 
-const TEST_SECRET = 'test_secret'
+//
+// Constants and types
+//
 
-enum Role {
-	unauthenticated,
-	authenticated,
-}
-
-// Access profiles
-const RESTRICTED = [Role.authenticated]
-const ALL_ROLES = [Role.unauthenticated, Role.authenticated]
-
-type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE'
+const ACCEPTED_CODES = [200, 400, 404]
 
 interface Endpoint {
 	method: HttpMethod
 	path: string
 	acceptedRoles: Role[]
 }
+
+//
+// Roles, access profiles and endpoints
+//
+
+enum Role {
+	unauthenticated,
+	authenticated,
+}
+
+const ALL_ROLES = [Role.unauthenticated, Role.authenticated]
+const AUTHENTICATED = [Role.authenticated]
+
+// Endpoint authentication matrix
+const endpoints: Endpoint[] = [
+	{ method: 'GET', path: '/auth/providers', acceptedRoles: ALL_ROLES },
+	{ method: 'GET', path: '/auth/login/microsoft', acceptedRoles: ALL_ROLES },
+	{ method: 'GET', path: '/auth/callback/microsoft', acceptedRoles: ALL_ROLES },
+	{ method: 'POST', path: '/auth/login', acceptedRoles: ALL_ROLES },
+	{ method: 'POST', path: '/auth/logout', acceptedRoles: AUTHENTICATED },
+	{ method: 'GET', path: '/auth/me', acceptedRoles: AUTHENTICATED },
+	{ method: 'GET', path: '/otp', acceptedRoles: AUTHENTICATED },
+	{ method: 'POST', path: '/otp', acceptedRoles: AUTHENTICATED },
+	{ method: 'GET', path: '/otp/:id', acceptedRoles: AUTHENTICATED },
+	{ method: 'POST', path: '/otp/:id', acceptedRoles: AUTHENTICATED },
+]
+
+//
+// 1. Test matrix completeness
+//
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE'
 
 interface AppRoute {
 	method: string
@@ -56,20 +91,6 @@ function getAppEndpoints(): Endpoint[] {
 	return [...unique.values()]
 }
 
-// Endpoint authentication matrix
-const endpoints: Endpoint[] = [
-	{ method: 'GET', path: '/auth/providers', acceptedRoles: ALL_ROLES },
-	{ method: 'GET', path: '/auth/login/microsoft', acceptedRoles: ALL_ROLES },
-	{ method: 'GET', path: '/auth/callback/microsoft', acceptedRoles: ALL_ROLES },
-	{ method: 'POST', path: '/auth/login', acceptedRoles: ALL_ROLES },
-	{ method: 'POST', path: '/auth/logout', acceptedRoles: RESTRICTED },
-	{ method: 'GET', path: '/auth/me', acceptedRoles: RESTRICTED },
-	{ method: 'GET', path: '/otp', acceptedRoles: RESTRICTED },
-	{ method: 'POST', path: '/otp', acceptedRoles: RESTRICTED },
-	{ method: 'GET', path: '/otp/:id', acceptedRoles: RESTRICTED },
-	{ method: 'POST', path: '/otp/:id', acceptedRoles: RESTRICTED },
-]
-
 test('Matrix covers all registered endpoints', () => {
 	const matrixKeys = new Set(endpoints.map(endpointKey))
 	const appEndpointKeys = new Set(getAppEndpoints().map(endpointKey))
@@ -80,6 +101,12 @@ test('Matrix covers all registered endpoints', () => {
 	expect(missingInMatrix).toEqual([])
 	expect(missingInApp).toEqual([])
 })
+
+//
+// 2. Test access control
+//
+
+const TEST_SECRET = 'test_secret'
 
 async function getAuthCookie(role: Role): Promise<string | undefined> {
 	if (role === Role.unauthenticated) {
@@ -99,7 +126,7 @@ async function getAuthCookie(role: Role): Promise<string | undefined> {
 function testEndpointAccess(endpoint: Endpoint, role: Role) {
 	const isAccepted = endpoint.acceptedRoles.includes(role)
 
-	test(`${endpoint.method} ${endpoint.path} -> ${isAccepted ? 'Allowed' : '401'}`, async () => {
+	test(`${endpoint.method} ${endpoint.path} -> ${isAccepted ? 'ok' : '401'}`, async () => {
 		const cookie = await getAuthCookie(role)
 		const headers: Record<string, string> = {}
 		if (cookie) {
@@ -112,7 +139,7 @@ function testEndpointAccess(endpoint: Endpoint, role: Role) {
 		})
 
 		if (isAccepted) {
-			expect(response.status).not.toBe(401)
+			expect(response.status).toBeOneOf(ACCEPTED_CODES)
 		} else {
 			expect(response.status).toBe(401)
 		}


### PR DESCRIPTION
Close #58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored auth matrix into a two-part suite: endpoint coverage checks and per-role access verification.
  * Expanded matrix to include more authentication and OTP routes.
  * Switched to dynamically building role-specific auth during tests and asserting accepted vs. unauthorized responses.
  * Improved route discovery to derive expected endpoints from the app's registered routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->