### PR TITLE
add endpoint and UI to archive entries 

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/client/src/components/EditDialog.tsx
+++ b/client/src/components/EditDialog.tsx
@@ -225,7 +225,7 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 							onClick={(): Promise<void> => handleArchive()}
 							disabled={submitting()}
 						>
-							Archive
+							Archivieren
 						</button>
 					</div>
 				</form>

--- a/client/src/components/EditDialog.tsx
+++ b/client/src/components/EditDialog.tsx
@@ -104,6 +104,37 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 		}
 	}
 
+	async function handleArchive(): Promise<void> {
+		if (
+			!confirm(
+				`Archive "${props.otp.issuer} (${props.otp.issuer_second}): ${props.otp.label}"?`,
+			)
+		) {
+			return
+		}
+
+		setError(null)
+		setSubmitting(true)
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: Hono RPC POST with params does not infer json parameter without server schema validator
+			const res = await (client.otp[':id'].archive.$post as any)({
+				param: { id: props.otp.id },
+			})
+
+			if (!res.ok) {
+				const msg = await read_api_error(res, 'Failed to archive OTP entry')
+				setError(msg)
+				return
+			}
+
+			await props.onSave()
+		} catch (_err) {
+			setError('An error occurred while archiving.')
+		} finally {
+			setSubmitting(false)
+		}
+	}
+
 	return (
 		<div class="modal-backdrop" role="presentation">
 			<button
@@ -187,6 +218,14 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 							disabled={submitting()}
 						>
 							Abbrechen
+						</button>
+						<button
+							type="button"
+							class="archive-button"
+							onClick={(): Promise<void> => handleArchive()}
+							disabled={submitting()}
+						>
+							Archive
 						</button>
 					</div>
 				</form>

--- a/client/src/css/modal.css
+++ b/client/src/css/modal.css
@@ -111,3 +111,33 @@
 .form-actions button {
 	flex: 1;
 }
+
+.archive-button {
+	padding: var(--gap-small) calc(var(--gap-small) * 2);
+	background-color: var(--color-danger-bg);
+	color: var(--color-danger);
+	border: 1px solid var(--color-danger);
+	border-radius: var(--corner-radius);
+	font-size: 1rem;
+	font-weight: 600;
+	cursor: pointer;
+	margin-top: 0.5rem;
+	transition:
+		background-color 0.2s,
+		border-color 0.2s,
+		color 0.2s;
+	margin-left: auto;
+	flex: 0 1 auto;
+	min-width: 8rem;
+}
+
+.archive-button:hover:not(:disabled) {
+	background-color: var(--color-danger-bg-hover);
+	border-color: var(--color-danger);
+	color: var(--color-danger);
+}
+
+.archive-button:disabled {
+	cursor: not-allowed;
+	opacity: 0.6;
+}

--- a/server/drizzle/0004_ancient_archive.sql
+++ b/server/drizzle/0004_ancient_archive.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `entries` ADD `archived_at` text;

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1779796505464,
       "tag": "0003_red_zaladane",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1783340400000,
+      "tag": "0004_ancient_archive",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,7 +1,7 @@
 import { Database } from 'bun:sqlite'
 import fs from 'node:fs'
 import path from 'node:path'
-import { eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/bun-sqlite'
 import { migrate } from 'drizzle-orm/bun-sqlite/migrator'
 import type { HashAlgorithm } from 'otplib'
@@ -44,8 +44,8 @@ function resolve_db_path(): string {
 	return path.join(data_dir, configured_path)
 }
 
-export function listEntries(): OtpDisplayInfo[] {
-	return db
+export function listEntries(includeArchived = false): OtpDisplayInfo[] {
+	const baseQuery = db
 		.select({
 			id: entries.id,
 			label: entries.label,
@@ -54,7 +54,12 @@ export function listEntries(): OtpDisplayInfo[] {
 			period: entries.period,
 		})
 		.from(entries)
-		.all()
+
+	if (includeArchived) {
+		return baseQuery.all()
+	}
+
+	return baseQuery.where(isNull(entries.archived_at)).all()
 }
 
 export function createEntry(obj: NewOtpEntry): OtpEntry {
@@ -70,6 +75,7 @@ export function createEntry(obj: NewOtpEntry): OtpEntry {
 		algorithm: algo as HashAlgorithm,
 		digits: obj.digits ?? 6,
 		period: obj.period ?? 30,
+		archived_at: null,
 	}
 
 	db.insert(entries).values(entry).run()
@@ -84,6 +90,21 @@ export function getEntryById(id: string): OtpEntry | null {
 
 export function updateEntry(id: string, updated: UpdateOtpEntry): void {
 	db.update(entries).set(updated).where(eq(entries.id, id)).run()
+}
+
+export function archiveEntry(id: string): string | null {
+	const existing = getEntryById(id)
+	if (!existing) {
+		return null
+	}
+
+	if (existing.archived_at) {
+		return existing.archived_at
+	}
+
+	const archivedAt = new Date().toISOString()
+	db.update(entries).set({ archived_at: archivedAt }).where(eq(entries.id, id)).run()
+	return archivedAt
 }
 
 export function getUserByEmail(email: string): User | null {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,7 +1,7 @@
 import { Database } from 'bun:sqlite'
 import fs from 'node:fs'
 import path from 'node:path'
-import { and, eq, isNull } from 'drizzle-orm'
+import { eq, isNull } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/bun-sqlite'
 import { migrate } from 'drizzle-orm/bun-sqlite/migrator'
 import type { HashAlgorithm } from 'otplib'

--- a/server/src/otp.test.ts
+++ b/server/src/otp.test.ts
@@ -14,6 +14,7 @@ describe('generateTotpCode', () => {
 			algorithm: 'sha1',
 			digits: 6,
 			period: 30,
+			archived_at: null,
 		}
 
 		expect(Result.unwrap(generateTotpCode(entry))).toHaveLength(6)

--- a/server/src/routes/auth-matrix.test.ts
+++ b/server/src/routes/auth-matrix.test.ts
@@ -50,6 +50,7 @@ const endpoints: Endpoint[] = [
 	{ method: 'POST', path: '/otp', acceptedRoles: AUTHENTICATED },
 	{ method: 'GET', path: '/otp/:id', acceptedRoles: AUTHENTICATED },
 	{ method: 'POST', path: '/otp/:id', acceptedRoles: AUTHENTICATED },
+	{ method: 'POST', path: '/otp/:id/archive', acceptedRoles: AUTHENTICATED },
 ]
 
 //

--- a/server/src/routes/otp_routes.test.ts
+++ b/server/src/routes/otp_routes.test.ts
@@ -238,4 +238,80 @@ describe('OTP routes', () => {
 		expect(stored?.issuer_second).toBe('Stable Second')
 		expect(stored?.secret).toBe('JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP')
 	})
+
+	test('archives an entry and returns archivedAt', async () => {
+		const headers = await getAuthHeaders()
+		const createResponse = await app.request('/otp', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json', ...headers },
+			body: JSON.stringify({
+				label: 'Archive me',
+				issuer: 'archive.example',
+				secret: 'JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP',
+			}),
+		})
+		const { id } = (await createResponse.json()) as { id: string }
+
+		const archiveResponse = await app.request(`/otp/${id}/archive`, {
+			method: 'POST',
+			headers: { ...headers },
+		})
+
+		expect(archiveResponse.status).toBe(200)
+		const archiveBody = (await archiveResponse.json()) as { archivedAt: string }
+		expect(archiveBody.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+
+		const stored = getEntryById(id)
+		expect(stored?.archived_at).toBe(archiveBody.archivedAt)
+	})
+
+	test('archived entries are hidden by default and can be included explicitly', async () => {
+		const headers = await getAuthHeaders()
+		const createResponse = await app.request('/otp', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json', ...headers },
+			body: JSON.stringify({
+				label: 'Hidden when archived',
+				issuer: 'archive.example',
+				secret: 'JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP',
+			}),
+		})
+		const { id } = (await createResponse.json()) as { id: string }
+
+		await app.request(`/otp/${id}/archive`, {
+			method: 'POST',
+			headers: { ...headers },
+		})
+
+		const defaultList = await app.request('/otp', {
+			headers: { ...headers },
+		})
+		expect(defaultList.status).toBe(200)
+		expect(await defaultList.json()).toEqual([])
+
+		const includeArchivedList = await app.request('/otp?includeArchived=true', {
+			headers: { ...headers },
+		})
+		expect(includeArchivedList.status).toBe(200)
+		expect(await includeArchivedList.json()).toEqual([
+			{
+				id,
+				label: 'Hidden when archived',
+				issuer: 'archive.example',
+				issuer_second: '',
+				period: 30,
+			},
+		])
+	})
+
+	test('returns 404 when archiving a non-existent entry', async () => {
+		const headers = await getAuthHeaders()
+		const archiveResponse = await app.request('/otp/missing/archive', {
+			method: 'POST',
+			headers: { ...headers },
+		})
+
+		expect(archiveResponse.status).toBe(404)
+		expect(await archiveResponse.json()).toEqual({ error: 'OTP entry not found' })
+	})
 })

--- a/server/src/routes/otp_routes.ts
+++ b/server/src/routes/otp_routes.ts
@@ -1,7 +1,7 @@
 import { Result } from 'better-result'
 import { Hono } from 'hono'
 import type { NewOtpEntry } from 'shared/src/types'
-import { createEntry, getEntryById, listEntries, updateEntry } from '../db'
+import { archiveEntry, createEntry, getEntryById, listEntries, updateEntry } from '../db'
 import { authMiddleware } from '../middleware/auth'
 import { generateTotpCode } from '../otp'
 import type { UpdateOtpEntry } from '../types'
@@ -11,7 +11,8 @@ export const otpApp = new Hono()
 
 	// GET /otp — list all entries
 	.get('/', (c) => {
-		return c.json(listEntries())
+		const includeArchived = c.req.query('includeArchived') === 'true'
+		return c.json(listEntries(includeArchived))
 	})
 
 	// POST /otp — create a new entry, return its id
@@ -70,4 +71,15 @@ export const otpApp = new Hono()
 			updateEntry(id, body)
 		}
 		return c.json({ success: true })
+	})
+
+	// POST /otp/:id/archive — archive an existing entry
+	.post('/:id/archive', (c) => {
+		const id = c.req.param('id')
+		const archivedAt = archiveEntry(id)
+		if (!archivedAt) {
+			return c.json({ error: 'OTP entry not found' }, 404)
+		}
+
+		return c.json({ archivedAt })
 	})

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -9,6 +9,7 @@ export const entries = sqliteTable('entries', {
 	algorithm: text('algorithm').notNull(),
 	digits: integer('digits').notNull(),
 	period: integer('period').notNull(),
+	archived_at: text('archived_at'),
 })
 
 export const users = sqliteTable('users', {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -8,6 +8,7 @@ export interface OtpEntry {
 	algorithm: HashAlgorithm
 	digits: number
 	period: number
+	archived_at: string | null
 }
 
 // Other fields are not updatable


### PR DESCRIPTION
close #8 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to archive OTP entries from the edit dialog.
  * Archived entries can now be included in OTP lists when requested.

* **Bug Fixes**
  * Archived entries are now hidden from the default OTP list.
  * Archiving a missing entry now returns a clear not-found error.

* **Chores**
  * Updated the Biome schema reference to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->