### PR TITLE
improve tag filter UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-## 0.1.1
-_unreleased_
+## unreleased
 
 - Prevent layout shifts in tag filter popup
+- Fix layout shift in edit dialog with unsaved changes
 - Correctly detect tag changes in edit dialog
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 0.1.1
+_unreleased_
+
+- Prevent layout shifts in tag filter popup
+- Correctly detect tag changes in edit dialog
+
+
 ## 0.1.0
 _2026-07-21_
 

--- a/client/src/components/EditDialog.tsx
+++ b/client/src/components/EditDialog.tsx
@@ -130,22 +130,9 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 
 		setSubmitting(true)
 		try {
-			// biome-ignore lint/suspicious/noExplicitAny: Hono RPC POST with params does not infer json parameter without server schema validator
-			const res = await (client.otp[':id'].$post as any)({
-				param: { id: props.otp.id },
-				json: {
-					label: labelVal,
-					issuer: issuer().trim(),
-					issuer_second: issuerSecond().trim(),
-				},
-			})
-
-			if (!res.ok) {
-				const msg = await read_api_error(res, 'Fehler beim Update des Eintrags')
-				setError(msg)
-				return
-			}
-
+			// Update tag assignments first: their baseline (initialTagIds) is
+			// tracked locally, so if the OTP update below fails afterwards,
+			// hasChanges() will not report already-persisted tags as unsaved.
 			const initial = initialTagIds()
 			const current = assignedTagIds()
 			const tagUpdates: { tagId: string; assigned: boolean }[] = [
@@ -172,6 +159,23 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 					return next
 				})
 			}
+
+			// biome-ignore lint/suspicious/noExplicitAny: Hono RPC POST with params does not infer json parameter without server schema validator
+			const res = await (client.otp[':id'].$post as any)({
+				param: { id: props.otp.id },
+				json: {
+					label: labelVal,
+					issuer: issuer().trim(),
+					issuer_second: issuerSecond().trim(),
+				},
+			})
+
+			if (!res.ok) {
+				const msg = await read_api_error(res, 'Fehler beim Update des Eintrags')
+				setError(msg)
+				return
+			}
+
 			await props.onSave()
 		} catch (_err) {
 			setError('Fehler beim Speichern.')

--- a/client/src/components/EditDialog.tsx
+++ b/client/src/components/EditDialog.tsx
@@ -25,12 +25,18 @@ type FormFieldProps = {
 	onInput: (value: string) => void
 }
 
+// visible=false hides the asterisk but reserves its space (unlike <Show>),
+// so toggling it never shifts surrounding content.
+const Asterisk = (props: { visible?: boolean }): JSX.Element => (
+	<span style={{ visibility: props.visible === false ? 'hidden' : 'visible' }}>* </span>
+)
+
 const FormField = (props: FormFieldProps): JSX.Element => (
 	<div class="form-row">
 		<div class={`form-group ${props.colClass}`}>
 			<label for={props.id} classList={{ 'field-changed': props.changed }}>
 				<Show when={props.changed}>
-					<i>* </i>
+					<Asterisk />
 				</Show>
 				{props.label}
 			</label>
@@ -286,7 +292,7 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 								classList={{ 'field-changed': isTagsChanged() }}
 							>
 								<Show when={isTagsChanged()}>
-									<i>* </i>
+									<Asterisk />
 								</Show>
 								Tags
 							</span>
@@ -325,10 +331,11 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 							disabled={submitting()}
 							classList={{ 'button-changed': hasChanges() }}
 						>
-							<Show when={hasChanges()}>
-								<i>* </i>
-							</Show>
+							<Asterisk visible={hasChanges()} />
 							{submitting() ? 'Speichern...' : 'Speichern'}
+							{/* Balance spacer: matches the reserved asterisk slot so the
+						label stays centered whether or not changes exist */}
+							<Asterisk visible={false} />
 						</button>
 						<button
 							type="button"

--- a/client/src/components/EditDialog.tsx
+++ b/client/src/components/EditDialog.tsx
@@ -162,8 +162,16 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 					setError(tagRes.error.message)
 					return
 				}
+				setInitialTagIds((prev) => {
+					const next = new Set(prev)
+					if (assigned) {
+						next.add(tagId)
+					} else {
+						next.delete(tagId)
+					}
+					return next
+				})
 			}
-
 			await props.onSave()
 		} catch (_err) {
 			setError('Fehler beim Speichern.')

--- a/client/src/components/EditDialog.tsx
+++ b/client/src/components/EditDialog.tsx
@@ -55,6 +55,7 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 	const [error, setError] = createSignal<string | null>(null)
 	const [allTags, setAllTags] = createSignal<TagWithMemberCount[]>([])
 	const [assignedTagIds, setAssignedTagIds] = createSignal<ReadonlySet<string>>(new Set())
+	const [initialTagIds, setInitialTagIds] = createSignal<ReadonlySet<string>>(new Set())
 
 	onMount(async () => {
 		const [tagsRes, entryTagsRes] = await Promise.all([
@@ -72,10 +73,12 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 			setError(entryTagsRes.error.message)
 			return
 		}
-		setAssignedTagIds(new Set(entryTagsRes.value.map((tag) => tag.id)))
+		const tagIds = new Set(entryTagsRes.value.map((tag) => tag.id))
+		setInitialTagIds(tagIds)
+		setAssignedTagIds(tagIds)
 	})
 
-	async function handleTagToggle(tagId: string, assigned: boolean): Promise<void> {
+	function handleTagToggle(tagId: string, assigned: boolean): void {
 		setError(null)
 
 		const next = new Set(assignedTagIds())
@@ -85,27 +88,26 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 			next.delete(tagId)
 		}
 		setAssignedTagIds(next)
-
-		const res = await set_entry_tag(props.otp.id, tagId, assigned)
-		if (Result.isError(res)) {
-			setAssignedTagIds((current) => {
-				const reverted = new Set(current)
-				if (assigned) {
-					reverted.delete(tagId)
-				} else {
-					reverted.add(tagId)
-				}
-				return reverted
-			})
-			setError(res.error.message)
-		}
 	}
 
 	const isIssuerChanged = (): boolean => issuer().trim() !== props.otp.issuer
 	const isIssuerSecondChanged = (): boolean => issuerSecond().trim() !== props.otp.issuer_second
 	const isLabelChanged = (): boolean => label().trim() !== props.otp.label
+	const isTagsChanged = (): boolean => {
+		const initial = initialTagIds()
+		const current = assignedTagIds()
+		if (initial.size !== current.size) {
+			return true
+		}
+		for (const id of current) {
+			if (!initial.has(id)) {
+				return true
+			}
+		}
+		return false
+	}
 	const hasChanges = (): boolean =>
-		isIssuerChanged() || isIssuerSecondChanged() || isLabelChanged()
+		isIssuerChanged() || isIssuerSecondChanged() || isLabelChanged() || isTagsChanged()
 
 	function handleClose(): void {
 		if (hasChanges()) {
@@ -142,6 +144,24 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 				const msg = await read_api_error(res, 'Fehler beim Update des Eintrags')
 				setError(msg)
 				return
+			}
+
+			const initial = initialTagIds()
+			const current = assignedTagIds()
+			const tagUpdates: { tagId: string; assigned: boolean }[] = [
+				...[...current]
+					.filter((id) => !initial.has(id))
+					.map((tagId) => ({ tagId, assigned: true })),
+				...[...initial]
+					.filter((id) => !current.has(id))
+					.map((tagId) => ({ tagId, assigned: false })),
+			]
+			for (const { tagId, assigned } of tagUpdates) {
+				const tagRes = await set_entry_tag(props.otp.id, tagId, assigned)
+				if (Result.isError(tagRes)) {
+					setError(tagRes.error.message)
+					return
+				}
 			}
 
 			await props.onSave()
@@ -249,7 +269,15 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 
 					<Show when={allTags().length > 0}>
 						<div class="edit-tags">
-							<span class="edit-tags__label">Tags</span>
+							<span
+								class="edit-tags__label"
+								classList={{ 'field-changed': isTagsChanged() }}
+							>
+								<Show when={isTagsChanged()}>
+									<i>* </i>
+								</Show>
+								Tags
+							</span>
 							<For each={allTags()}>
 								{(tag: TagWithMemberCount): JSX.Element => (
 									<label
@@ -268,10 +296,7 @@ function DialogContent(props: EditDialogProps): JSX.Element {
 											onChange={(
 												e: Event & { currentTarget: HTMLInputElement },
 											): void => {
-												void handleTagToggle(
-													tag.id,
-													e.currentTarget.checked,
-												)
+												handleTagToggle(tag.id, e.currentTarget.checked)
 											}}
 										/>
 										{tag.name}

--- a/client/src/components/OtpListItem.tsx
+++ b/client/src/components/OtpListItem.tsx
@@ -222,8 +222,6 @@ const OtpListItem = (props: Props): JSX.Element => {
 				otp={props.otp}
 				onClose={(): void => {
 					setIsEditing(false)
-					// Tag assignments apply immediately, so refresh on close
-					void props.refetch()
 				}}
 				onSave={async (): Promise<void> => {
 					setIsEditing(false)

--- a/client/src/components/TagFilter.tsx
+++ b/client/src/components/TagFilter.tsx
@@ -1,6 +1,6 @@
 import { IconFilter2, IconFilter2Cancel } from '@tabler/icons-solidjs'
 import type { TagInfo } from 'shared/src/types'
-import { createEffect, createSignal, For, type JSX, onCleanup, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, For, type JSX, onCleanup, Show } from 'solid-js'
 
 type Props = {
 	tags: TagInfo[]
@@ -15,19 +15,22 @@ type TagChipProps = {
 	onToggle: (tagId: string) => void
 }
 
-const TagChip = (props: TagChipProps): JSX.Element => (
-	<button
-		type="button"
-		class="tag-chip tag-filter__chip"
-		classList={{ 'tag-filter__chip--active': props.isActive() }}
-		style={{ '--tag-color': props.tag.color }}
-		onClick={(): void => props.onToggle(props.tag.id)}
-		aria-pressed={props.isActive()}
-		title={`Nach Tag "${props.tag.name}" filtern`}
-	>
-		{props.tag.name}
-	</button>
-)
+const TagChip = (props: TagChipProps): JSX.Element => {
+	const isActive = createMemo(props.isActive)
+	return (
+		<button
+			type="button"
+			class="tag-chip tag-filter__chip"
+			classList={{ 'tag-filter__chip--active': isActive() }}
+			style={{ '--tag-color': props.tag.color }}
+			onClick={(): void => props.onToggle(props.tag.id)}
+			aria-pressed={isActive()}
+			title={`Nach Tag "${props.tag.name}" filtern`}
+		>
+			{props.tag.name}
+		</button>
+	)
+}
 
 type TagFilterButtonProps = {
 	buttonRef: (el: HTMLButtonElement) => void

--- a/client/src/components/TagFilter.tsx
+++ b/client/src/components/TagFilter.tsx
@@ -9,90 +9,142 @@ type Props = {
 	onClear: () => void
 }
 
+type TagChipProps = {
+	tag: TagInfo
+	isActive: () => boolean
+	onToggle: (tagId: string) => void
+}
+
+const TagChip = (props: TagChipProps): JSX.Element => (
+	<button
+		type="button"
+		class="tag-chip tag-filter__chip"
+		classList={{ 'tag-filter__chip--active': props.isActive() }}
+		style={{ '--tag-color': props.tag.color }}
+		onClick={(): void => props.onToggle(props.tag.id)}
+		aria-pressed={props.isActive()}
+		title={`Nach Tag "${props.tag.name}" filtern`}
+	>
+		{props.tag.name}
+	</button>
+)
+
+type TagFilterButtonProps = {
+	buttonRef: (el: HTMLButtonElement) => void
+	badgeCount: number
+	isOpen: () => boolean
+	hasActiveTags: () => boolean
+	onToggle: () => void
+}
+
+const TagFilterButton = (props: TagFilterButtonProps): JSX.Element => (
+	<button
+		type="button"
+		ref={props.buttonRef}
+		class="icon-button tag-filter__button"
+		classList={{ 'tag-filter__button--active': props.hasActiveTags() }}
+		onClick={props.onToggle}
+		aria-label="Nach Tags filtern"
+		aria-expanded={props.isOpen()}
+		title="Nach Tags filtern"
+	>
+		<IconFilter2 size={18} stroke="2" aria-hidden="true" />
+		<Show when={props.hasActiveTags()}>
+			<span class="tag-filter__badge">{props.badgeCount}</span>
+		</Show>
+	</button>
+)
+
+type TagFilterPopoverProps = {
+	tags: TagInfo[]
+	activeTagIds: string[]
+	onToggle: (tagId: string) => void
+	onClear: () => void
+}
+
+const TagFilterPopover = (props: TagFilterPopoverProps): JSX.Element => (
+	<div class="tag-filter__popover">
+		<Show when={props.activeTagIds.length > 0}>
+			<button
+				type="button"
+				class="tag-filter__clear"
+				onClick={props.onClear}
+				title="Tag-Filter zurücksetzen"
+			>
+				<IconFilter2Cancel size={16} stroke="2" aria-hidden="true" />
+				Zurücksetzen
+			</button>
+		</Show>
+		<div class="tag-filter__chips">
+			<For each={props.tags}>
+				{(tag: TagInfo): JSX.Element => (
+					<TagChip
+						tag={tag}
+						isActive={(): boolean => props.activeTagIds.includes(tag.id)}
+						onToggle={props.onToggle}
+					/>
+				)}
+			</For>
+		</div>
+	</div>
+)
+
 const TagFilter = (props: Props): JSX.Element => {
 	const [open, setOpen] = createSignal(false)
 	let rootRef: HTMLDivElement | undefined
 	let buttonRef: HTMLButtonElement | undefined
 
+	const close = (): void => {
+		setOpen(false)
+	}
+	const hasActiveTags = (): boolean => props.activeTagIds.length > 0
+
+	const handlePointerDown = (event: PointerEvent): void => {
+		if (rootRef && !rootRef.contains(event.target as Node)) {
+			close()
+		}
+	}
+	const handleKeyDown = (event: KeyboardEvent): void => {
+		if (event.key === 'Escape') {
+			close()
+			buttonRef?.focus()
+		}
+	}
+
 	// Close the popover on outside click or Escape
+	const removeListeners = (): void => {
+		document.removeEventListener('pointerdown', handlePointerDown)
+		document.removeEventListener('keydown', handleKeyDown)
+	}
 	createEffect(() => {
 		if (!open()) {
 			return
 		}
-
-		const handlePointerDown = (event: PointerEvent): void => {
-			if (rootRef && !rootRef.contains(event.target as Node)) {
-				setOpen(false)
-			}
-		}
-		const handleKeyDown = (event: KeyboardEvent): void => {
-			if (event.key === 'Escape') {
-				setOpen(false)
-				buttonRef?.focus()
-			}
-		}
-
 		document.addEventListener('pointerdown', handlePointerDown)
 		document.addEventListener('keydown', handleKeyDown)
-		onCleanup(() => {
-			document.removeEventListener('pointerdown', handlePointerDown)
-			document.removeEventListener('keydown', handleKeyDown)
-		})
+		onCleanup(removeListeners)
 	})
 
 	return (
 		<div class="tag-filter" ref={rootRef}>
-			<button
-				type="button"
-				ref={buttonRef}
-				class="icon-button tag-filter__button"
-				classList={{ 'tag-filter__button--active': props.activeTagIds.length > 0 }}
-				onClick={(): void => {
+			<TagFilterButton
+				buttonRef={(el: HTMLButtonElement): void => {
+					buttonRef = el
+				}}
+				badgeCount={props.activeTagIds.length}
+				isOpen={open}
+				hasActiveTags={hasActiveTags}
+				onToggle={(): void => {
 					setOpen((prev) => !prev)
 				}}
-				aria-label="Nach Tags filtern"
-				aria-expanded={open()}
-				title="Nach Tags filtern"
-			>
-				<IconFilter2 size={18} stroke="2" aria-hidden="true" />
-				<Show when={props.activeTagIds.length > 0}>
-					<span class="tag-filter__badge">{props.activeTagIds.length}</span>
-				</Show>
-			</button>
+			/>
 			<Show when={open()}>
-				<div class="tag-filter__popover">
-					<Show when={props.activeTagIds.length > 0}>
-						<button
-							type="button"
-							class="tag-filter__clear"
-							onClick={(): void => props.onClear()}
-							title="Tag-Filter zurücksetzen"
-						>
-							<IconFilter2Cancel size={16} stroke="2" aria-hidden="true" />
-							Filter zurücksetzen
-						</button>
-					</Show>
-					<div class="tag-filter__chips">
-						<For each={props.tags}>
-							{(tag: TagInfo): JSX.Element => {
-								const isActive = (): boolean => props.activeTagIds.includes(tag.id)
-								return (
-									<button
-										type="button"
-										class="tag-chip tag-filter__chip"
-										classList={{ 'tag-filter__chip--active': isActive() }}
-										style={{ '--tag-color': tag.color }}
-										onClick={(): void => props.onToggle(tag.id)}
-										aria-pressed={isActive()}
-										title={`Nach Tag "${tag.name}" filtern`}
-									>
-										{tag.name}
-									</button>
-								)
-							}}
-						</For>
-					</div>
-				</div>
+				<TagFilterPopover
+					tags={props.tags}
+					activeTagIds={props.activeTagIds}
+					onToggle={props.onToggle}
+					onClear={props.onClear}
+				/>
 			</Show>
 		</div>
 	)

--- a/client/src/components/TagFilter.tsx
+++ b/client/src/components/TagFilter.tsx
@@ -64,17 +64,16 @@ type TagFilterPopoverProps = {
 
 const TagFilterPopover = (props: TagFilterPopoverProps): JSX.Element => (
 	<div class="tag-filter__popover">
-		<Show when={props.activeTagIds.length > 0}>
-			<button
-				type="button"
-				class="tag-filter__clear"
-				onClick={props.onClear}
-				title="Tag-Filter zurücksetzen"
-			>
-				<IconFilter2Cancel size={16} stroke="2" aria-hidden="true" />
-				Zurücksetzen
-			</button>
-		</Show>
+		<button
+			type="button"
+			class="tag-filter__clear"
+			onClick={props.onClear}
+			disabled={props.activeTagIds.length === 0}
+			title="Tag-Filter zurücksetzen"
+		>
+			<IconFilter2Cancel size={16} stroke="2" aria-hidden="true" />
+			Zurücksetzen
+		</button>
 		<div class="tag-filter__chips">
 			<For each={props.tags}>
 				{(tag: TagInfo): JSX.Element => (

--- a/client/src/css/modal.css
+++ b/client/src/css/modal.css
@@ -110,6 +110,8 @@
 
 .form-actions button {
 	flex: 1;
+	/* Keep the change asterisk and label on one line (no wrap above the text) */
+	white-space: nowrap;
 }
 
 .archive-button {

--- a/client/src/css/tags.css
+++ b/client/src/css/tags.css
@@ -103,6 +103,16 @@
 	color: var(--color-text-muted);
 }
 
+.edit-tags__label.field-changed {
+	font-style: italic;
+}
+
+.edit-tags__label.field-changed i {
+	color: hsl(35, 100%, 45%);
+	margin-right: 0.2rem;
+	font-style: normal;
+}
+
 .edit-tags__option {
 	cursor: pointer;
 

--- a/client/src/css/tags.css
+++ b/client/src/css/tags.css
@@ -189,7 +189,12 @@
 	font-size: 0.78rem;
 	cursor: pointer;
 
-	&:hover {
+	&:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+
+	&:not(:disabled):hover {
 		background: var(--color-bg-hover);
 		border-color: var(--color-border-strong);
 		color: var(--color-text);

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -82,7 +82,7 @@ test('tags can be created, assigned, filtered and deleted', async ({ page }) => 
 	await expect(page.locator('.otp-list__item')).toHaveCount(1)
 
 	// The clear button resets the filter
-	await page.getByRole('button', { name: 'Filter zurücksetzen' }).click()
+	await page.getByRole('button', { name: 'Zurücksetzen' }).click()
 	await expect(arbeitChip).toHaveAttribute('aria-pressed', 'false')
 	await expect(filterButton.locator('.tag-filter__badge')).toHaveCount(0)
 	await expect(page.locator('.otp-list__item')).toHaveCount(1)

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -44,8 +44,8 @@ test('tags can be created, assigned, filtered and deleted', async ({ page }) => 
 	await tagOption.click()
 	await expect(tagOption.locator('input')).toBeChecked()
 
-	// Chip appears on the entry and the member count increases
-	await page.getByRole('button', { name: 'Abbrechen' }).click()
+	// Tag changes are pending until saved; the chip appears and the member count increases
+	await page.getByRole('button', { name: 'Speichern' }).click()
 	await expect(page.locator('.otp-list__tags .tag-chip')).toHaveText('Arbeit')
 
 	await page.getByRole('button', { name: 'Tags verwalten' }).click()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed layout shifts in the tag filter popup and edit dialog.
  - Corrected detection and saving of tag changes in the edit dialog.
  - Unsaved tag changes are now clearly indicated before saving.
  - Prevented edit action labels and change indicators from wrapping.

- **UI Improvements**
  - The tag filter reset control is always available and disabled when unused.
  - Improved disabled-state styling and clearer reset labeling.
  - Closing an edit dialog without saving no longer refreshes the entry list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->